### PR TITLE
Dzelge xxx byoa

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 - Fixed wrongly names PV and PVC for stores. Used to be called datapools.
 - Fixed that _raise_for_no_access would cause a 500 error when the database searched for does not exist
+- Fixed issues when using inline user code for generating xcubes. The hub now stores any cube configuration/user codes
+  in a persistent volume shared with the xcube gen2 Jobs. The xcube gen2 command line has been changed accordingly from
+  using pipes to passing the config as file parameter.
 
 ## Changes in v2.1.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,10 @@
 
 ### New Features
 
-- Changed the operation PUT cubegens from application/json to multipart content. xcube-gen2 now uploads the cube 
-  configuration as JSON file. In addition, xcube-gen2 might upload a zip file containing BYOA Python code.
-- The flask server can now be configured to run in debug mode using the en var XCUBE_HUB_DEBUG 
+- Added an operation PUT cubegens/code using content type multipart/form-data. This allows xcube-gen2 to upload the cube 
+  configuration as JSON file and user code as a zipped archive.
+- The flask server can now be configured to run in debug mode using the en var XCUBE_HUB_DEBUG
+
 
 ### Fixes
 

--- a/test/core/test_cubegens.py
+++ b/test/core/test_cubegens.py
@@ -52,7 +52,7 @@ _CFG = {
 
 _OUTPUT = """
 Awaiting generator configuration JSON from TTY...
-Cube generator configuration loaded from TTY.
+Cube generator configuration loaded from /user-code/id.yaml.
 {
     "dataset_descriptor": {
         "data_id": "test_cube.zarr",

--- a/test/core/test_oauth.py
+++ b/test/core/test_oauth.py
@@ -32,7 +32,7 @@ class TestOauth(unittest.TestCase):
             oauth.get_user_by_credentials(token='dfasvdsav', client_id='döoasvnoösdvi', client_secret='sdvdsv')
 
         self.assertEqual(404, e.exception.status_code)
-        self.assertEqual('No users not found.', str(e.exception))
+        self.assertEqual('No users found.', str(e.exception))
 
         m.get('https://edc.eu.auth0.com/api/v2/users', json=[user.to_dict(), user.to_dict()])
 

--- a/xcube_hub/controllers/cubegens.py
+++ b/xcube_hub/controllers/cubegens.py
@@ -33,12 +33,13 @@ def create_cubegen(body: JsonObject, token_info: Dict):
 
             body = CubegenConfig.from_dict(body_dict)
             body = process_user_code(cfg=body, user_code=user_code)
+            body = body.to_dict()
 
         user_id = token_info['user_id']
         email = token_info['email']
         token = token_info['token']
 
-        cubegen = cubegens.create(user_id=user_id, email=email, token=token, cfg=body.to_dict())
+        cubegen = cubegens.create(user_id=user_id, email=email, token=token, cfg=body)
         return api.ApiResponse.success(cubegen)
     except api.ApiError as e:
         return e.response

--- a/xcube_hub/core/cubegens.py
+++ b/xcube_hub/core/cubegens.py
@@ -65,7 +65,7 @@ def create_cubegen_object(cubegen_id: str, cfg: AnyDict, info_only: bool = False
     info_flag = " -i " if info_only else ""
 
     cmd = ["/bin/bash", "-c", f"source activate xcube && echo \'{json.dumps(cfg)}\' "
-                              f"| xcube --traceback gen2 {info_flag} -vvv --stores {stores_file}"]
+                              f"| xcube --traceback gen2 {info_flag} --stores {stores_file}"]
 
     sh_envs = [
         client.V1EnvVar(name="SH_CLIENT_ID", value=sh_client_id),
@@ -267,10 +267,11 @@ def info(user_id: str, email: str, body: JsonObject, token: Optional[str] = None
         raise api.ApiError(400, res)
     res = res.replace("Awaiting generator configuration JSON from TTY...", "")
     res = res.replace("Cube generator configuration loaded from TTY.", "")
+    res = res.replace("'", '"')
     try:
         processing_request = json.loads(res)
     except JSONDecodeError as e:
-        raise api.ApiError(400, str(e))
+        raise api.ApiError(400, str(e), output=res)
 
     if 'input_configs' in body:
         input_config = body['input_configs'][0]

--- a/xcube_hub/core/oauth.py
+++ b/xcube_hub/core/oauth.py
@@ -25,7 +25,7 @@ def get_user_by_credentials(token: str, client_id: str, client_secret: str) -> S
 
     res = r.json()
     if len(res) == 0:
-        raise api.ApiError(404, f"No users not found.")
+        raise api.ApiError(404, f"No users found.")
     if len(res) > 1:
         raise api.ApiError(400, f"More than one user found.")
 

--- a/xcube_hub/models/cubegen_config_code_config.py
+++ b/xcube_hub/models/cubegen_config_code_config.py
@@ -17,7 +17,7 @@ class CubegenConfigCodeConfig(Model):
     Do not edit the class manually.
     """
 
-    def __init__(self, file_set=None, callable_ref=None, callable_params=None):  # noqa: E501
+    def __init__(self, file_set=None, callable_ref=None, callable_params=None, inline_code=None):  # noqa: E501
         """CubegenConfigCodeConfig - a model defined in OpenAPI
 
         :param file_set: The file_set of this CubegenConfigCodeConfigFileSet.  # noqa: E501
@@ -26,22 +26,27 @@ class CubegenConfigCodeConfig(Model):
         :type callable_ref: str
         :param callable_params: The callable_params of this CubegenConfigCodeConfig.  # noqa: E501
         :type callable_params: Dict[str, object]
+        :param inline_code: The inline_code of this CubegenConfigCodeConfig.  # noqa: E501
+        :type inline_code: Dict[str, object]
         """
         self.openapi_types = {
             'file_set': CubegenConfigCodeConfigFileSet,
             'callable_ref': str,
-            'callable_params': Dict[str, object]
+            'callable_params': Dict[str, object],
+            'inline_code': str
         }
 
         self.attribute_map = {
             'file_set': 'file_set',
             'callable_ref': 'callable_ref',
-            'callable_params': 'callable_params'
+            'callable_params': 'callable_params',
+            'inline_code': 'inline_code'
         }
 
         self._file_set = file_set
         self._callable_ref = callable_ref
         self._callable_params = callable_params
+        self._inline_code = inline_code
 
     @classmethod
     def from_dict(cls, dikt) -> 'CubegenConfigCodeConfig':
@@ -116,3 +121,24 @@ class CubegenConfigCodeConfig(Model):
         """
 
         self._callable_params = callable_params
+
+    @property
+    def inline_code(self):
+        """Gets the inline_code of this CubegenConfigCodeConfig.
+
+
+        :return: The inline_code of this CubegenConfigCodeConfig.
+        :rtype: str
+        """
+        return self.inline_code
+
+    @inline_code.setter
+    def inline_code(self, inline_code):
+        """Sets the inline_code of this CubegenConfigCodeConfig.
+
+
+        :param inline_code: The callable_params of this CubegenConfigCodeConfig.
+        :type inline_code: str
+        """
+
+        self._inline_code = inline_code

--- a/xcube_hub/models/cubegen_config_code_config.py
+++ b/xcube_hub/models/cubegen_config_code_config.py
@@ -130,7 +130,7 @@ class CubegenConfigCodeConfig(Model):
         :return: The inline_code of this CubegenConfigCodeConfig.
         :rtype: str
         """
-        return self.inline_code
+        return self._inline_code
 
     @inline_code.setter
     def inline_code(self, inline_code):

--- a/xcube_hub/resources/openapi.yaml
+++ b/xcube_hub/resources/openapi.yaml
@@ -469,12 +469,6 @@ paths:
                   format: binary
                 body:
                   type: string
-#          multipart/form-data:
-#            schema:
-#              type: object
-#              properties:
-#                user_code:
-#                  type: string
         description: Cubegen configuration
         required: true
       responses:
@@ -490,7 +484,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
           description: Api Error
-        "415":
+        "413":
           content:
             application/json:
               schema:
@@ -509,6 +503,56 @@ paths:
       tags:
         - cubegens
       x-openapi-router-controller: xcube_hub.controllers.cubegens
+#  /cubgens/upload:
+#    put:
+#      description: |
+#        Create a jcubegen
+#      operationId: create_cubegen_upload
+#      requestBody:
+#        content:
+#          multipart/form-data:
+#            schema:
+#              type: object
+#              properties:
+#                user_code:
+#                  type: string
+#                  format: binary
+#                body:
+#                  type: string
+#        description: Cubegen configuration
+#        required: true
+#      responses:
+#        "200":
+#          content:
+#            application/json:
+#              schema:
+#                $ref: '#/components/schemas/ApiCubegenResponse'
+#          description: Create a cubegen
+#        "400":
+#          content:
+#            application/json:
+#              schema:
+#                $ref: '#/components/schemas/ApiErrorResponse'
+#          description: Api Error
+#        "413":
+#          content:
+#            application/json:
+#              schema:
+#                $ref: '#/components/schemas/ApiErrorResponse'
+#          description: Api Error
+#        "404":
+#          content:
+#            application/json:
+#              schema:
+#                $ref: '#/components/schemas/ApiErrorResponse'
+#          description: User not found
+#      security:
+#        - oAuthorization:
+#            - manage:cubegens
+#      summary: Create a cubegen
+#      tags:
+#        - cubegens
+#      x-openapi-router-controller: xcube_hub.controllers.cubegens
   /cubegens/info:
     post:
       description: |

--- a/xcube_hub/resources/openapi.yaml
+++ b/xcube_hub/resources/openapi.yaml
@@ -503,56 +503,61 @@ paths:
       tags:
         - cubegens
       x-openapi-router-controller: xcube_hub.controllers.cubegens
-#  /cubgens/upload:
-#    put:
-#      description: |
-#        Create a jcubegen
-#      operationId: create_cubegen_upload
-#      requestBody:
-#        content:
-#          multipart/form-data:
-#            schema:
-#              type: object
-#              properties:
-#                user_code:
-#                  type: string
-#                  format: binary
-#                body:
-#                  type: string
-#        description: Cubegen configuration
-#        required: true
-#      responses:
-#        "200":
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/ApiCubegenResponse'
-#          description: Create a cubegen
-#        "400":
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/ApiErrorResponse'
-#          description: Api Error
-#        "413":
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/ApiErrorResponse'
-#          description: Api Error
-#        "404":
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/ApiErrorResponse'
-#          description: User not found
-#      security:
-#        - oAuthorization:
-#            - manage:cubegens
-#      summary: Create a cubegen
-#      tags:
-#        - cubegens
-#      x-openapi-router-controller: xcube_hub.controllers.cubegens
+  /cubegens/code:
+    put:
+      description: |
+        Create a cubegen passing user code and cube config as json and zip file
+      operationId: create_cubegen_code
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                user_code:
+                  type: string
+                  format: binary
+                body:
+                  type: string
+            encoding:
+              user_code:
+                contentType: application/zip
+              body:
+                contentType: application/json
+        description: Cubegen configuration
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiCubegenResponse'
+          description: Create a cubegen
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Api Error
+        "413":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: Api Error
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+          description: User not found
+      security:
+        - oAuthorization:
+            - manage:cubegens
+      summary: Create a cubegen
+      tags:
+        - cubegens
+      x-openapi-router-controller: xcube_hub.controllers.cubegens
   /cubegens/info:
     post:
       description: |

--- a/xcube_hub/resources/openapi.yaml
+++ b/xcube_hub/resources/openapi.yaml
@@ -460,7 +460,7 @@ paths:
       operationId: create_cubegen
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
               type: object
               properties:
@@ -1164,6 +1164,8 @@ components:
         callable_params:
           type: object
           additionalProperties: true
+        inline_code:
+          type: string
     CubegenConfigCubeConfig:
       properties:
         variable_names:

--- a/xcube_hub/resources/openapi.yaml
+++ b/xcube_hub/resources/openapi.yaml
@@ -469,11 +469,12 @@ paths:
                   format: binary
                 body:
                   type: string
-            encoding:
-              user_code:
-                contentType: application/zip
-              body:
-                contentType: application/json
+#          multipart/form-data:
+#            schema:
+#              type: object
+#              properties:
+#                user_code:
+#                  type: string
         description: Cubegen configuration
         required: true
       responses:


### PR DESCRIPTION
When accepting this PR, the hub will:

- Have an operation PUT cubegens/code using content type multipart/form-data. This allows xcube-gen2 to upload the cube 
  configuration as JSON file and user code as a zipped archive.
- have fixed issues when using inline user code for generating xcubes. The hub now stores any cube configuration/user codes
  in a persistent volume shared with the xcube gen2 Jobs. The xcube gen2 command line has been changed accordingly from
  using pipes to passing the config as file parameter.